### PR TITLE
Fix bug in SuffixArray

### DIFF
--- a/code/SearchString.hpp
+++ b/code/SearchString.hpp
@@ -50,7 +50,7 @@ class SuffixArray {
 
     SuffixArray(string st) {
         n = st.size();
-        __log_n = log2(n) + 1;
+        __log_n = log2(n) + 2;
         ra = vector<vector<int>>(__log_n, vector<int>(n));
         sa = vector<int>(n);
 


### PR DESCRIPTION
This code failed on input string `bababa`, as the number of iterations performed was ONE short of what were required to produce the correct result. Normally, I would fix this by using a `while (true)` loop and checking if `rank == n`, see example [here](https://pastebin.com/RtB6PnEu), but in this case, the size of the matrix was hardcoded to [logn][n] so just increasing logn was sufficient.